### PR TITLE
Add ReleaseGroupSecondaryTypeUserType (Hibernate user type)

### DIFF
--- a/src/main/java/fm/last/musicbrainz/data/hibernate/ReleaseGroupSecondaryTypeUserType.java
+++ b/src/main/java/fm/last/musicbrainz/data/hibernate/ReleaseGroupSecondaryTypeUserType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013 The musicbrainz-data Authors
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package fm.last.musicbrainz.data.hibernate;
+
+import fm.last.musicbrainz.data.model.ReleaseGroupSecondaryType;
+
+public class ReleaseGroupSecondaryTypeUserType extends
+        AbstractEnumUserType<ReleaseGroupSecondaryType> {
+
+    public ReleaseGroupSecondaryTypeUserType() {
+        super(ReleaseGroupSecondaryType.class);
+    }
+
+    @Override
+    public Integer getIntegerValue(ReleaseGroupSecondaryType type) {
+        return type.getId();
+    }
+
+    @Override
+    public ReleaseGroupSecondaryType getEnumConstant(Integer id) {
+        return ReleaseGroupSecondaryType.valueOf(id);
+    }
+
+}


### PR DESCRIPTION
I forgot to commit the ReleaseGroupSecondaryTypeUserType class for the pull request number 6.
https://github.com/lastfm/musicbrainz-data/pull/6
